### PR TITLE
Fix link to FAQ in examples

### DIFF
--- a/docs/examples/debug-ssh.md
+++ b/docs/examples/debug-ssh.md
@@ -7,7 +7,7 @@ Certified for:
 - [x] `x86_64`
 
 !!! info "Use a private repository"
-    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq.md).
+    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq).
 
 ## Try out the action on your agent
 

--- a/docs/examples/docker.md
+++ b/docs/examples/docker.md
@@ -8,7 +8,7 @@ Certified for:
 - [x] `arm64` including Raspberry Pi 4
 
 !!! info "Use a private repository"
-    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq.md).
+    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq).
 
 ## Try out the action on your agent
 

--- a/docs/examples/k3s.md
+++ b/docs/examples/k3s.md
@@ -8,7 +8,7 @@ Certified for:
 - [x] `arm64` including Raspberry Pi 4
 
 !!! info "Use a private repository"
-    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq.md).
+    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq).
 
 ## Try out the action on your agent
 

--- a/docs/examples/kernel.md
+++ b/docs/examples/kernel.md
@@ -7,7 +7,7 @@ Certified for:
 - [x] `x86_64`
 
 !!! info "Use a private repository"
-    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq.md).
+    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq).
 
 ## Try out the action on your agent
 

--- a/docs/examples/kind.md
+++ b/docs/examples/kind.md
@@ -8,7 +8,7 @@ Certified for:
 - [x] `arm64` including Raspberry Pi 4
 
 !!! info "Use a private repository"
-    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq.md).
+    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq).
 
 ## Try out the action on your agent
 

--- a/docs/examples/matrix.md
+++ b/docs/examples/matrix.md
@@ -8,7 +8,7 @@ Certified for:
 - [x] `arm64` including Raspberry Pi 4
 
 !!! info "Use a private repository"
-    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq.md).
+    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq).
 
 ## Try out the action on your agent
 

--- a/docs/examples/openfaas-helm.md
+++ b/docs/examples/openfaas-helm.md
@@ -14,7 +14,7 @@ Certified for:
 - [x] `arm64`
 
 !!! info "Use a private repository"
-    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq.md).
+    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq).
 
 ## Try out the action on your agent
 

--- a/docs/examples/openfaas-publish.md
+++ b/docs/examples/openfaas-publish.md
@@ -15,7 +15,7 @@ Certified for:
 - [x] `x86_64`
 
 !!! info "Use a private repository"
-    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq.md).
+    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq).
 
 ## Try out the action on your agent
 

--- a/docs/examples/system-info.md
+++ b/docs/examples/system-info.md
@@ -8,7 +8,7 @@ Certified for:
 - [x] `arm64` including Raspberry Pi 4
 
 !!! info "Use a private repository"
-    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq.md).
+    GitHub recommends using a private repository with self-hosted runners. Learn why in the [FAQ](/faq).
 
 ## Try out the action on your agent
 


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix broken link to FAQ on top of every example page.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The 404 page is displayed when clicking the FAQ link on the top of the examples pages. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran docs site locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
