### PR TITLE
Fix 404's on the install agent page

### DIFF
--- a/docs/install-agent.md
+++ b/docs/install-agent.md
@@ -167,6 +167,6 @@ Make sure you've read the [Actuated EULA](https://github.com/self-actuated/actua
 
 You can now start your first build and see it run on your actuated agent.
 
-[Start a build on your agent](test-build)
+[Start a build on your agent](/test-build)
 
-See also: [Troubleshooting your agent](troubleshooting)
+See also: [Troubleshooting your agent](/troubleshooting)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There are two busted links at the bottom of the page which broke my flow (but the sidebar links worked), just adding the missing / helped

## How Has This Been Tested?
Ran it locally and worked fine.

- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
