### PR TITLE
Update docs to run the agent without ./start.sh script

### DIFF
--- a/docs/examples/kvm-guest.md
+++ b/docs/examples/kvm-guest.md
@@ -12,14 +12,11 @@ There are some prerequisites to enable KVM support:
 
 1. Make sure [nested virtualization is enabled](https://ostechnix.com/how-to-enable-nested-virtualization-in-kvm-in-linux/) on the Agent host.
 
-2. Modify the `start.sh` file for your Actuated Agent and add the `kvm` suffix to the kernel-ref tag:
+2. Edit `/etc/default/actuated` for your Actuated Agent and add the `kvm` suffix to the `AGENT_KERNEL_REF` variable:
 
     ```diff
-    sudo -E agent up \
-        --image-ref=ghcr.io/openfaasltd/actuated-ubuntu20.04:x86-64-latest \
-    -   --kernel-ref=ghcr.io/openfaasltd/actuated-kernel-5.10.77:x86-64-latest \
-    +   --kernel-ref=ghcr.io/openfaasltd/actuated-kernel-5.10.77:x86-64-latest-kvm \
-        --listen-addr 127.0.0.1:
+    - AGENT_KERNEL_REF="ghcr.io/openfaasltd/actuated-kernel-5.10.77:x86-64-latest"
+    + AGENT_KERNEL_REF="ghcr.io/openfaasltd/actuated-kernel-5.10.77:x86-64-latest-kvm"
     ```
 
 3. Restart the Agent to use the new kernel.

--- a/docs/expose-agent.md
+++ b/docs/expose-agent.md
@@ -23,11 +23,17 @@ Determine the public IP of your instance:
 
 Now imagine that your sub-domain is `agent.example.com`, you need to create a DNS A record of `agent.example.com=141.73.80.100`, changing both the sub-domain and IP to your own.
 
-Once created, edit the start.sh file on the agent and add two flags:
+Once the agent is installed, edit /etc/default/actuated on the agent and set the following two variables:
 
 ```
---letsencrypt-domain agent.example.com \
---letsencrypt-email webmaster@agent.example.com
+AGENT_LETSENCRYPT_DOMAIN="agent.example.com"
+AGENT_LETSENCRYPT_EMAIL="webmaster@agent.example.com"
+```
+
+Restart the agent:
+
+```bash
+sudo systemctl restart actuated
 ```
 
 Your agent's endpoint URL is going to be: `https://agent.example.com` on port 443


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update the installation steps to use the new `install-service` command.

Update any reference to the `./start.sh` script and change them to use the env file `/etc/default/actuated`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Keep the docs up to date with changes to the agent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran the docs site locally to verify the changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
