### PR TITLE
Fixes for local GitHub cache instructions

### DIFF
--- a/docs/tasks/local-github-cache.md
+++ b/docs/tasks/local-github-cache.md
@@ -1,6 +1,6 @@
 # Run a local GitHub Cache
 
-The cache for GitHub Actions can speed up CI/CD pipelines. Hosted runners are placed close to the cache which means the latency is very low. Self-hosted runners can also make good use of this cache. Just like caching container images on the host in (a registry mirror)[/tasks/registry-mirror/], you can also get a speed boost over the hosted cache by running your own cache directly on the host.
+The cache for GitHub Actions can speed up CI/CD pipelines. Hosted runners are placed close to the cache which means the latency is very low. Self-hosted runners can also make good use of this cache. Just like caching container images on the host in [a registry mirror](/tasks/registry-mirror/), you can also get a speed boost over the hosted cache by running your own cache directly on the host.
 
 To improve cache speeds with Actuated runners you can run a self-hosted S3 server and switch out the official [actions/cache@v3](https://github.com/actions/cache) with [tespkg/actions-cache@v1](https://github.com/tespkg/actions-cache). The tespkg/actions-cache@v1 can target S3 instead of the proprietary GitHub cache.
 
@@ -54,7 +54,7 @@ cat >> /tmp/s3.conf <<EOF
 }
 EOF
 
-mkldir -p /etc/seaweedfs
+mkdir -p /etc/seaweedfs
 sudo mv /tmp/s3.conf /etc/seaweedfs/s3.conf
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Fix link to registry mirror page.
- Fix typo in instructions to create `/etc/seaweedfs/s3.conf`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/self-actuated/docs.actuated.dev/blob/master/CONTRIBUTING.md))

Ensure links are working and commands can be copy pasted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Ran the docs locally to verify the link to the registry mirror page is working

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
