### PR TITLE
Badge - compatibility with MD syntax

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -51,8 +51,14 @@ We have a sponsored program with the CNCF and Ampere for various Open Source pro
 
 Sponsored projects are required to [add our GitHub badge](/images/actuated-badge.png) to the top of their README file for each repository where the actuated is being used, along with any other GitHub badges such as build status, code coverage, etc.
 
-```
+```html
 <a href="https://actuated.dev/"><img alt="Arm CI sponsored by Actuated" src="https://docs.actuated.dev/images/actuated-badge.png" width="120px"></img></a>
+```
+
+or
+
+```md
+[![Arm CI sponsored by Actuated](https://img.shields.io/badge/SA_actuated.dev-004BDD)](https://actuated.dev/)
 ```
 
 For an example of what this would look like, see the [inletsctl project README](https://github.com/inlets/inletsctl).


### PR DESCRIPTION
## Description
Possibility to add actuated.dev badge using markdown syntax.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/self-actuated/docs.actuated.dev/blob/master/CONTRIBUTING.md))

Fixes: #18

PR for OpenTelemetry Automatic Instrumentation introducing support for ARM64. https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/3277

Current requirements, force us to allow html syntax in documentation files. If possible, it will be great to avoid this.

One of the solutions is to use common shields.io system to generate badges, alternatively you could add badge image in the proper size (120px) and support something like:

```md
[![Arm CI sponsored by Actuated](https://docs.actuated.dev/images/actuated-badge-120.png)](https://actuated.dev/)
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Snippet from PR, here:
[![Arm CI sponsored by Actuated](https://img.shields.io/badge/SA_actuated.dev-004BDD)](https://actuated.dev/)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality), just documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
