### PR TITLE
Document macOS agent installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ mkdocs serve
 
 Access the site at http://127.0.0.1:8000
 
+### Docker
+
+Run the documentation site in a container:
+
+```bash
+docker run --rm -it -p 8000:8000 -v "$PWD:/docs" squidfunk/mkdocs-material:latest
+```
+
+Access the site at http://127.0.0.1:8000
+
 
 ## Contributing
 

--- a/docs/install-agent.md
+++ b/docs/install-agent.md
@@ -1,5 +1,8 @@
 # Add your first agent to actuated
 
+This page covers installation on a Linux host. To run isolated macOS jobs on
+Apple Silicon, see [Install the macOS Agent](/install-macos-agent/).
+
 actuated is split into three parts:
 
 1. An Actuated Agent (agent) that you run on your own machines or VMs (server), which can launch a VM with a single-use GitHub Actions runner.

--- a/docs/install-macos-agent.md
+++ b/docs/install-macos-agent.md
@@ -116,13 +116,20 @@ There are two options for enrolling the host:
 ### 5. Install the service
 
 Starting a macOS VM requires the agent user's login keychain to be unlocked.
-For unattended recovery after a reboot, FileVault must be off and automatic
-login must be enabled:
+To recover without intervention after a reboot, the host therefore uses
+automatic login.
+
+FileVault prevents automatic login. For unattended operation,
+[turn off FileVault](https://support.apple.com/guide/mac-help/turn-off-filevault-on-mac-mchlp2560/mac),
+confirm that it is off, then enable automatic login:
 
 ```bash
-sudo fdesetup status
+sudo fdesetup status  # Expect: FileVault is Off.
 sudo ~/.actuated/bin/agent autologin --user "$(id -un)"
 ```
+
+If FileVault remains enabled, an operator must unlock the Mac and log in as the
+agent user after every reboot before jobs can start.
 
 Install the service as the agent user, not with `sudo`.
 
@@ -183,9 +190,13 @@ Expected results:
 
 ### 7. Run a test job
 
-Target the Mac from a minimal workflow:
+Create a GitHub Actions workflow:
 
 ```yaml
+name: macOS agent test
+
+on: workflow_dispatch
+
 jobs:
   build:
     runs-on: actuated-macos-arm64-2cpu-8gb
@@ -195,7 +206,8 @@ jobs:
       - run: sudo -n true
 ```
 
-The job should complete, and the single-use VM should be removed afterward.
+Trigger the workflow. The job should complete, and the single-use VM should be
+removed afterward.
 
 ## Keep the agent and base image current
 

--- a/docs/install-macos-agent.md
+++ b/docs/install-macos-agent.md
@@ -1,0 +1,224 @@
+# Install and join the macOS agent
+
+This guide installs the native agent on an Apple Silicon Mac, prepares its
+base image, connects the host to Actuated, and runs a test job.
+
+## Installation
+
+### 1. Prepare the host
+
+You need:
+
+* An Apple Silicon Mac with at least 16 GB RAM.
+* Enough free disk space for macOS, the base image, and job clones.
+* A macOS user to run the agent. Do not run the agent as root.
+* Apple's Command Line Tools and [arkade](https://github.com/alexellis/arkade).
+
+Install the Command Line Tools and prevent the host from sleeping:
+
+```bash
+xcode-select --install
+sudo pmset -a sleep 0 displaysleep 0 disksleep 0
+```
+
+Use shorter DHCP leases for the ephemeral VMs:
+
+```bash
+sudo defaults write \
+  /Library/Preferences/SystemConfiguration/com.apple.InternetSharing.default.plist \
+  bootpd -dict DHCPLeaseTimeSecs -int 600
+```
+
+The guest agent releases its DHCP lease before shutdown, but Apple's `bootpd`
+may retain the lease record and continue allocating addresses sequentially.
+Keep the shorter lease time so abandoned addresses return to the pool quickly.
+
+Review the [Actuated EULA](https://github.com/self-actuated/actuated/blob/master/EULA.md)
+and the macOS software licence shown when the base image is installed.
+
+### 2. Install the agent
+
+Download and unpack the latest macOS agent release:
+
+```bash
+arkade oci install \
+  ghcr.io/openfaasltd/actuated-agent-macos \
+  ~/.actuated/bin
+```
+
+Confirm that the installed binary reports its version and Git commit:
+
+```bash
+~/.actuated/bin/agent version
+```
+
+The license is available in the email you received when you purchased your
+subscription.
+
+Run the following, then paste in your license, hit Enter once, then Control+D
+to save the file:
+
+```bash
+cat > ~/.actuated/LICENSE
+```
+
+### 3. Prepare the base image
+
+Follow [Prepare the macOS base image](prepare-macos-base.md). It documents both
+the recommended automatic setup and the manual macOS Setup Assistant workflow.
+
+Return here after `~/.actuated/base.bundle` has been provisioned.
+
+### 4. Enroll the host
+
+There are two options for enrolling the host:
+
+=== "Automatic enrollment"
+
+    Use the controller details supplied during onboarding:
+
+    ```bash
+    export ACTUATED_CONTROLLER="https://controller.example.com"
+    export ACTUATED_ENROLL_TOKEN="..."
+    export ACTUATED_AGENT_URL="https://mac-agent.example.com"
+
+    ~/.actuated/bin/agent autoenroll
+    ```
+
+    `ACTUATED_AGENT_URL` is the public HTTPS endpoint where the Actuated
+    control plane will reach this agent. Use the externally reachable URL
+    configured for this host. The endpoint may become reachable only after the
+    service is installed in the next step.
+
+    The command creates `~/.actuated/TOKEN`, `key_rsa`, and `key_rsa.pub` on
+    first use. Re-running it keeps those credentials and updates the controller
+    record.
+
+=== "Manual enrollment"
+
+    Generate the local credentials and a controller configuration entry:
+
+    ```bash
+    ~/.actuated/bin/agent keygen \
+      --customer CUSTOMER \
+      --orgs GITHUB_ORG \
+      --endpoint https://mac-agent.example.com
+    ```
+
+    `--endpoint` is the public HTTPS endpoint where the Actuated control plane
+    will reach this agent. Use the externally reachable URL configured for
+    this host.
+
+    Share the generated `hosts.yaml` configuration with the Actuated team. We
+    will confirm when the host has been added to the control plane and is ready
+    to accept jobs.
+
+### 5. Install the service
+
+Starting a macOS VM requires the agent user's login keychain to be unlocked.
+For unattended recovery after a reboot, FileVault must be off and automatic
+login must be enabled:
+
+```bash
+sudo fdesetup status
+sudo ~/.actuated/bin/agent autologin --user "$(id -un)"
+```
+
+Install the service as the agent user, not with `sudo`.
+
+=== "Direct connection"
+
+    ```bash
+    ~/.actuated/bin/agent install
+    ```
+
+=== "Inlets tunnel"
+
+    An [inlets tunnel](https://docs.inlets.dev/cloud/) can provide a public
+    endpoint for an agent on a private network. When using one, run the tunnel
+    client and bind the agent to loopback:
+
+    ```bash
+    ~/.actuated/bin/agent install \
+      --addr "127.0.0.1:8080"
+    ```
+
+The command uses the current agent binary, `~/.actuated` as its work
+directory, and `~/.actuated/base.bundle` as the base image. Use `--work-dir`
+or `--base` only when those defaults need to change.
+
+We recommend enabling automatic runner updates. Append
+`--schedule-runner-updates` to the `install` command above to install a
+second LaunchAgent that updates the GitHub Actions runner in the base image
+every day at 04:00. This keeps the base image on a supported GitHub runner
+version.
+
+### 6. Verify the installation
+
+Check the local service and view its logs through the agent CLI:
+
+```bash
+~/.actuated/bin/agent service status
+~/.actuated/bin/agent service logs --lines 100
+
+curl -s \
+  -H "Authorization: Bearer $(cat ~/.actuated/TOKEN)" \
+  http://127.0.0.1:8080/api/capacity
+```
+
+Confirm that the host appears as online in the
+[Actuated Dashboard](https://dashboard.actuated.com).
+
+Expected results:
+
+* `service status` reports a running `com.openfaas.actuated-agent` service.
+* Capacity returns JSON containing `"status":"running"`.
+* The [Actuated Dashboard](https://dashboard.actuated.com) reports the host as
+  online.
+
+### 7. Run a test job
+
+Target the Mac from a minimal workflow:
+
+```yaml
+jobs:
+  build:
+    runs-on: actuated-macos-arm64-2cpu-8gb
+    steps:
+      - uses: actions/checkout@v7
+      - run: sw_vers
+      - run: sudo -n true
+```
+
+The job should complete, and the single-use VM should be removed afterward.
+
+## Keep the agent and base image current
+
+Upgrade the installed host agent from its published OCI image:
+
+```bash
+~/.actuated/bin/agent upgrade
+~/.actuated/bin/agent service restart
+~/.actuated/bin/agent version
+```
+
+The `upgrade` command replaces the installed agent when a newer version is
+available.
+
+The host binary embeds the guest agent, but upgrading the host does not modify
+an existing base image. After upgrading, inject the embedded guest agent and
+the latest GitHub Actions runner into the base with:
+
+```bash
+~/.actuated/bin/agent base update-runner
+```
+
+The command waits for running jobs to finish, then safely updates the base
+image.
+
+The command blocks until the update finishes. Follow its progress in another
+Terminal with:
+
+```bash
+~/.actuated/bin/agent service logs --follow
+```

--- a/docs/install-macos-agent.md
+++ b/docs/install-macos-agent.md
@@ -143,9 +143,14 @@ Install the service as the agent user, not with `sudo`.
       --addr "127.0.0.1:8080"
     ```
 
-The command uses the current agent binary, `~/.actuated` as its work
-directory, and `~/.actuated/base.bundle` as the base image. Use `--work-dir`
-or `--base` only when those defaults need to change.
+The command uses the current agent binary, `~/.actuated` as its work directory,
+and `~/.actuated/base.bundle` as the default base image. Use `--work-dir` when
+the default work directory needs to change.
+
+The `--base` flag selects the image used for every job VM and cannot be
+overridden per job. If your jobs need Xcode, first
+[prepare an image with the required version](prepare-macos-base.md#add-xcode-into-the-base-image),
+then pass its path to `--base` when installing the service.
 
 We recommend enabling automatic runner updates. Append
 `--schedule-runner-updates` to the `install` command above to install a

--- a/docs/prepare-macos-base.md
+++ b/docs/prepare-macos-base.md
@@ -156,28 +156,4 @@ specify it when
   --base ~/.actuated/base-xcode.bundle
 ```
 
-## Verify the base image
-
-Verification is optional. Always test a disposable clone rather than the base
-image itself:
-
-```bash
-~/.actuated/bin/agent vm clone \
-  --from ~/.actuated/base.bundle \
-  --to ~/.actuated/smoke.bundle
-
-~/.actuated/bin/agent vm run \
-  --bundle ~/.actuated/smoke.bundle &
-
-~/.actuated/bin/agent vm agent-health \
-  --bundle ~/.actuated/smoke.bundle
-
-~/.actuated/bin/agent vm rm \
-  --bundle ~/.actuated/smoke.bundle \
-  --force
-```
-
-The health command should return JSON describing the guest. Keep
-`base.bundle` stopped; the agent clones it for each job.
-
 Next, return to [Install and join the macOS agent](install-macos-agent.md#4-enroll-the-host).

--- a/docs/prepare-macos-base.md
+++ b/docs/prepare-macos-base.md
@@ -4,8 +4,8 @@ The macOS agent creates its base VM locally from a restore image downloaded
 directly from Apple. Actuated does not distribute a macOS base image.
 
 Preparing the base image installs macOS, configures the guest agent, and adds
-the GitHub Actions runner. The agent uses this base as a template and creates a
-disposable clone for each job VM.
+Apple's Command Line Tools and the GitHub Actions runner. The agent uses this
+base as a template and creates a disposable clone for each job VM.
 
 Complete the host requirements and [install the agent binary](install-macos-agent.md#2-install-the-agent)
 before preparing the image. Run all agent commands as the regular macOS user
@@ -40,8 +40,8 @@ Both methods create the same base bundle at `~/.actuated/base.bundle`.
     ```
 
     When setup finishes, leave the `oobe` command running. Open a second
-    Terminal, install the GitHub Actions runner into the base image, then shut
-    down the VM:
+    Terminal, install Apple's Command Line Tools and the GitHub Actions runner
+    into the base image, then shut down the VM:
 
     ```bash
     ~/.actuated/bin/agent base provision \
@@ -81,8 +81,8 @@ Both methods create the same base bundle at `~/.actuated/base.bundle`.
     Enter the `runner` password when prompted. The VM shuts down and the
     `base create` command exits after the guest agent is installed.
 
-    Start the VM again, install the GitHub Actions runner into the base image,
-    then shut down the VM:
+    Start the VM again, install Apple's Command Line Tools and the GitHub
+    Actions runner into the base image, then shut down the VM:
 
     ```bash
     ~/.actuated/bin/agent vm run \
@@ -98,9 +98,10 @@ Both methods create the same base bundle at `~/.actuated/base.bundle`.
 If `latest` cannot be installed on the host, download a compatible IPSW from
 Apple and pass its local path to `--ipsw` instead.
 
-The prepared base image now contains the GitHub Actions runner. Per-job
-credentials are supplied to disposable clones and are never stored in the
-base.
+The `base provision` command installs Apple's Command Line Tools in the guest
+before it installs the GitHub Actions runner. The prepared base image therefore
+provides tools such as Git and Clang to every disposable job VM. Per-job
+credentials are supplied to disposable clones and are never stored in the base.
 
 ## Verify the base image
 

--- a/docs/prepare-macos-base.md
+++ b/docs/prepare-macos-base.md
@@ -1,0 +1,129 @@
+# Prepare the macOS base image
+
+The macOS agent creates its base VM locally from a restore image downloaded
+directly from Apple. Actuated does not distribute a macOS base image.
+
+Preparing the base image installs macOS, configures the guest agent, and adds
+the GitHub Actions runner. The agent uses this base as a template and creates a
+disposable clone for each job VM.
+
+Complete the host requirements and [install the agent binary](install-macos-agent.md#2-install-the-agent)
+before preparing the image. Run all agent commands as the regular macOS user
+that will run the service, not as root.
+
+## Choose an image preparation method
+
+The automatic method is recommended. It completes the macOS Setup Assistant
+without user interaction. The manual method opens the VM console and leaves
+the macOS Setup Assistant to the operator.
+
+Both methods create the same base bundle at `~/.actuated/base.bundle`.
+
+=== "Automatic"
+
+    Create the VM from Apple's latest restore image supported by the agent:
+
+    ```bash
+    ~/.actuated/bin/agent base create \
+      --ipsw latest \
+      --bundle ~/.actuated/base.bundle
+    ```
+
+    The agent downloads the IPSW from Apple, which can take a few minutes.
+
+    Start the VM and let the agent complete the macOS Setup Assistant. The
+    default guest account is `runner` with password `runner`.
+
+    ```bash
+    ~/.actuated/bin/agent base oobe \
+      --bundle ~/.actuated/base.bundle
+    ```
+
+    When setup finishes, leave the `oobe` command running. Open a second
+    Terminal, install the GitHub Actions runner into the base image, then shut
+    down the VM:
+
+    ```bash
+    ~/.actuated/bin/agent base provision \
+      --bundle ~/.actuated/base.bundle
+
+    ~/.actuated/bin/agent vm agent-shutdown \
+      --bundle ~/.actuated/base.bundle
+    ```
+
+=== "Manual"
+
+    Create the VM and open its console:
+
+    ```bash
+    ~/.actuated/bin/agent base create \
+      --ipsw latest \
+      --bundle ~/.actuated/base.bundle
+    ```
+
+    The agent downloads the IPSW from Apple, which can take a few minutes.
+
+    Complete the macOS Setup Assistant as follows:
+
+    1. Select the language and region.
+    2. Set up the Mac as new and skip accessibility setup.
+    3. Create the local account using `runner` for the full name, account name,
+       and password.
+    4. Skip Apple Account sign-in. The guest must not use an Apple Account.
+    5. Complete the privacy and analytics screens and wait for the desktop.
+
+    Open Terminal inside the VM and run:
+
+    ```bash
+    sudo "/Volumes/My Shared Files/guest-agent" init
+    ```
+
+    Enter the `runner` password when prompted. The VM shuts down and the
+    `base create` command exits after the guest agent is installed.
+
+    Start the VM again, install the GitHub Actions runner into the base image,
+    then shut down the VM:
+
+    ```bash
+    ~/.actuated/bin/agent vm run \
+      --bundle ~/.actuated/base.bundle &
+
+    ~/.actuated/bin/agent base provision \
+      --bundle ~/.actuated/base.bundle
+
+    ~/.actuated/bin/agent vm agent-shutdown \
+      --bundle ~/.actuated/base.bundle
+    ```
+
+If `latest` cannot be installed on the host, download a compatible IPSW from
+Apple and pass its local path to `--ipsw` instead.
+
+The prepared base image now contains the GitHub Actions runner. Per-job
+credentials are supplied to disposable clones and are never stored in the
+base.
+
+## Verify the base image
+
+Verification is optional. If you verify the image, always test a disposable
+clone, not the base itself:
+
+```bash
+~/.actuated/bin/agent vm clone \
+  --from ~/.actuated/base.bundle \
+  --to ~/.actuated/smoke.bundle
+
+~/.actuated/bin/agent vm run \
+  --bundle ~/.actuated/smoke.bundle &
+
+~/.actuated/bin/agent vm agent-health \
+  --bundle ~/.actuated/smoke.bundle
+
+~/.actuated/bin/agent vm rm \
+  --bundle ~/.actuated/smoke.bundle \
+  --force
+```
+
+The health command should return JSON describing the guest. Keep
+`base.bundle` stopped; the agent clones it for each job.
+
+Next, return to [Install and join the macOS agent](install-macos-agent.md#4-enroll-the-host).

--- a/docs/prepare-macos-base.md
+++ b/docs/prepare-macos-base.md
@@ -156,4 +156,35 @@ specify it when
   --base ~/.actuated/base-xcode.bundle
 ```
 
+## Verify the base image
+
+Verify the base image:
+
+```bash
+~/.actuated/bin/agent base verify \
+  --bundle ~/.actuated/base.bundle
+```
+
+The command boots a disposable clone and checks the Actuated agent, Command Line
+Tools, and Actions runner. When an Xcode bundle is selected, it also checks the
+Xcode version and configured platform SDK. It then shuts down and removes the
+clone.
+
+Example output:
+
+```text
+$ ~/.actuated/bin/agent base verify \
+  --bundle ~/.actuated/base.bundle
+
+   Verifying base.bundle (base)
+ ✓ Cloning the base image base.bundle.verify
+ ✓ Booting the clone (8.3s)
+ ✓ Checking the guest agent f90c2b35c2e79ed9efc03124b6b42b0ed7e017cc, macOS 26.2
+ ✓ Checking the Command Line Tools git version 2.50.1 (Apple Git-155), Apple clang version 21.0.0 (20.1s)
+ ✓ Checking the Actions runner 2.336.0
+ ✓ Shutting down and removing the clone (6.9s)
+
+✓ base.bundle is ready to serve jobs
+```
+
 Next, return to [Install and join the macOS agent](install-macos-agent.md#4-enroll-the-host).

--- a/docs/prepare-macos-base.md
+++ b/docs/prepare-macos-base.md
@@ -1,15 +1,18 @@
 # Prepare the macOS base image
 
-The macOS agent creates its base VM locally from a restore image downloaded
-directly from Apple. Actuated does not distribute a macOS base image.
+When enrolling a new Apple Mac for use with actuated, you must first prepare a
+base image from Apple's IPSW restore image. The restore image will be booted,
+and walk through the setup wizard, and install actuated's guest agent. From
+there, two additional stages set up the Command Line Tools CLT (such as git,
+Swift, etc), then you can follow further steps to install Xcode on top to build
+native applications for targets such as iOS.
 
-Preparing the base image installs macOS, configures the guest agent, and adds
-Apple's Command Line Tools and the GitHub Actions runner. The agent uses this
-base as a template and creates a disposable clone for each job VM.
+Actuated does not distribute macOS due to restrictions in the EULA limiting
+redistribution.
 
-Complete the host requirements and [install the agent binary](install-macos-agent.md#2-install-the-agent)
-before preparing the image. Run all agent commands as the regular macOS user
-that will run the service, not as root.
+Complete the host requirements and
+[install the agent binary](install-macos-agent.md#2-install-the-agent) first,
+then run all commands as the regular service user, not root.
 
 ## Choose an image preparation method
 
@@ -98,15 +101,65 @@ Both methods create the same base bundle at `~/.actuated/base.bundle`.
 If `latest` cannot be installed on the host, download a compatible IPSW from
 Apple and pass its local path to `--ipsw` instead.
 
-The `base provision` command installs Apple's Command Line Tools in the guest
-before it installs the GitHub Actions runner. The prepared base image therefore
-provides tools such as Git and Clang to every disposable job VM. Per-job
-credentials are supplied to disposable clones and are never stored in the base.
+The prepared base image now contains Apple's Command Line Tools and the GitHub
+Actions runner. Per-job credentials are supplied to disposable clones and are
+never stored in the base.
+
+## Add Xcode into the base image
+
+The default base image contains Apple's Command Line Tools, but not the full
+Xcode application or additional Apple platform support. If the runner needs
+Xcode, create a separate Xcode base image after completing the provisioning
+steps above.
+
+Make sure [Xcode](https://developer.apple.com/xcode/resources/) is installed on
+the host, then build the Xcode image from the provisioned base. By default, the
+agent uses the newest installed version:
+
+```bash
+~/.actuated/bin/agent base xcode \
+  --from ~/.actuated/base.bundle \
+  --to ~/.actuated/base-xcode.bundle
+```
+
+The command clones the provisioned base, adds Xcode and the iOS SDK, then seals
+`base-xcode.bundle` without modifying `base.bundle`. Creating the Xcode image
+takes approximately 6-10 minutes.
+
+The `--platform` flag can be used to select which additional Apple platform
+support Xcode downloads into the base image. It accepts `iOS`, `watchOS`,
+`tvOS`, or `visionOS`, and defaults to `iOS`. Use `--platform ''` to install
+Xcode without downloading an additional platform.
+
+If multiple Xcode versions are installed, select one by its version or provide
+its path explicitly:
+
+```bash
+~/.actuated/bin/agent base xcode \
+  --from ~/.actuated/base.bundle \
+  --to ~/.actuated/base-xcode.bundle \
+  --xcode-version 26.6
+
+~/.actuated/bin/agent base xcode \
+  --from ~/.actuated/base.bundle \
+  --to ~/.actuated/base-xcode.bundle \
+  --xcode-app /Applications/Xcode-26.6.app
+```
+
+Each macOS agent uses one base image for all of its job VMs. Individual jobs
+cannot select a different image. To configure the agent to use the Xcode image,
+specify it when
+[installing the macOS agent service](install-macos-agent.md#5-install-the-service):
+
+```bash
+~/.actuated/bin/agent install \
+  --base ~/.actuated/base-xcode.bundle
+```
 
 ## Verify the base image
 
-Verification is optional. If you verify the image, always test a disposable
-clone, not the base itself:
+Verification is optional. Always test a disposable clone rather than the base
+image itself:
 
 ```bash
 ~/.actuated/bin/agent vm clone \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,9 +73,8 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
-      # emoji_generator: !!python/name:pymdownx.emoji.to_svg
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.inlinehilite
   - pymdownx.magiclink
   - pymdownx.mark
@@ -97,7 +96,11 @@ nav:
   - Onboarding:
       - Register your GitHub Organisation: register.md
       - Provision a Server: provision-server.md
-      - Install the Agent: install-agent.md
+      - Install the Linux Agent: install-agent.md
+      - Install the macOS Agent:
+          - Install and join the agent: install-macos-agent.md
+          - Prepare the base image: prepare-macos-base.md
+      - Expose an agent: expose-agent.md
       - Run a test build: test-build.md
   - Tasks:
     - Right Size the VM: tasks/right-size-vm.md


### PR DESCRIPTION
## Description

Add installation and enrollment instructions for the native macOS agent.

Document automatic and manual base-image preparation.

## Motivation and Context

Provide a complete onboarding path for running the Actuated agent on Apple
Silicon.

- [ ] I have raised an issue to propose this change ([required](https://github.com/self-actuated/docs.actuated.com/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

- Rendered the documentation using the MkDocs Material Docker image.
- Reviewed both macOS pages through the live preview.
- Checked the documented commands against the tested end-to-end installation
  workflow.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`